### PR TITLE
Add dependency on `sass`

### DIFF
--- a/scss.gemspec
+++ b/scss.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = []
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "sass"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This will allow you to actually get `sass` installed if you acidentally install
`scss`.  It's a common "gem stub" workflow to have a dependency on the gem you
actually want. i.e https://rubygems.org/gems/autotest
